### PR TITLE
feat: Add AI Video Summarizer to sidebar navigation

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -6,13 +6,14 @@ import {
   Film, 
   Search, 
   Activity,
-  Sparkles // Added for the new tool
+  Sparkles, // Icon for AI Video Summarizer
+  MessageSquareText // Icon for Arabia Comment Mapper
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export default function Sidebar() {
   const location = useLocation();
-  
+
   const navItems = [
     {
       name: 'Channel Analytics',
@@ -45,9 +46,14 @@ export default function Sidebar() {
       icon: <Activity size={20} />
     },
     {
-      name: 'AI Video Summarizer',
+      name: 'AI Video Summarizer', // Added from feat/gemini-video-summarizer
       path: '/tools/video-summarizer',
       icon: <Sparkles size={20} />
+    },
+    {
+      name: 'Arabia Comment Mapper', // Kept from main
+      path: '/tools/arabia-comment-mapper',
+      icon: <MessageSquareText size={20} />
     }
   ];
 
@@ -85,4 +91,3 @@ export default function Sidebar() {
     </aside>
   );
 }
-

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -46,12 +46,12 @@ export default function Sidebar() {
       icon: <Activity size={20} />
     },
     {
-      name: 'AI Video Summarizer', // Added from feat/gemini-video-summarizer
+      name: 'AI Video Summarizer',
       path: '/tools/video-summarizer',
       icon: <Sparkles size={20} />
     },
     {
-      name: 'Arabia Comment Mapper', // Kept from main
+      name: 'Arabia Comment Mapper',
       path: '/tools/arabia-comment-mapper',
       icon: <MessageSquareText size={20} />
     }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -5,7 +5,8 @@ import {
   Database, 
   Film, 
   Search, 
-  Activity
+  Activity,
+  Sparkles // Added for the new tool
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -42,6 +43,11 @@ export default function Sidebar() {
       name: 'Trending Checker',
       path: '/tools/trending-checker',
       icon: <Activity size={20} />
+    },
+    {
+      name: 'AI Video Summarizer',
+      path: '/tools/video-summarizer',
+      icon: <Sparkles size={20} />
     }
   ];
 


### PR DESCRIPTION
This commit adds the newly created 'AI Video Summarizer' to the main sidebar navigation in `Sidebar.jsx`.

The link includes the 'Sparkles' icon and directs you to the `/tools/video-summarizer` page. This enhances discoverability of the feature.