### PR TITLE
feat: Add Arabia Comment Mapper to Home Page & review Gemini examples

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,7 +7,8 @@ import {
   Search, 
   Activity,
   ArrowRight,
-  Sparkles // Add new icon
+  Sparkles,
+  MessageSquareText // Added for Arabia Comment Mapper
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
@@ -62,6 +63,13 @@ export default function Home() {
       icon: <Sparkles size={24} />,
       path: '/tools/video-summarizer',
       color: 'bg-teal-100 dark:bg-teal-900'
+    },
+    {
+      title: 'Arabia Comment Mapper',
+      description: 'Analyze YouTube comments to estimate commenter nationality from Arab countries using channel data and AI dialect analysis.',
+      icon: <MessageSquareText size={24} />,
+      path: '/tools/arabia-comment-mapper',
+      color: 'bg-green-100 dark:bg-green-900'
     }
   ];
 


### PR DESCRIPTION
This commit includes two main updates:

1.  **Add Arabia Comment Mapper to Home Page:**
    - The "Arabia Comment Mapper" tool is now featured on the application's home page (`src/pages/Home.jsx`).
    - A new card with a description, icon, and link to the tool has been added for better discoverability.

2.  **Review of Gemini Example Comments Logic:**
    - Investigated the issue of "No example comments to display" for the Gemini-based analysis.
    - Confirmed that the logic for collecting example comments in `performSingleAggregation` is correct: it attempts to find examples for the top 4 Arab countries identified by the Gemini analysis.
    - The absence of example comments for the Gemini section is likely if Gemini's analysis frequently results in 'Unknown' or does not identify specific Arab countries with enough consistency to place them in its top results.
    - The Gemini API prompt was also reviewed and deemed adequate for its purpose.

No changes were made to the example collection code or the Gemini prompt itself as they appear to function as intended. The display of Gemini examples is contingent on the quality and specificity of the analysis results provided by the Gemini API for the given comments.