### PR TITLE
fix: Add ErrorBoundary to LookalikeFinderPage and review data access

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AppProvider } from './contexts/AppContext';
 import Layout from './components/layout/Layout';
+import ErrorBoundary from './components/utils/ErrorBoundary'; // Added
 import './App.css';
 
 // Lazy load tool components
@@ -80,7 +81,9 @@ function App() {
             } />
             <Route path="tools/lookalike-finder" element={
               <Suspense fallback={<LoadingFallback />}>
-                <LookalikeFinderPage />
+                <ErrorBoundary>
+                  <LookalikeFinderPage />
+                </ErrorBoundary>
               </Suspense>
             } />
             <Route path="tools/pubgmini" element={

--- a/src/components/utils/ErrorBoundary.jsx
+++ b/src/components/utils/ErrorBoundary.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error: error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // You can also log the error to an error reporting service
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
+    this.setState({ errorInfo: errorInfo });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <div className="container mx-auto p-4 text-center">
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+            <strong className="font-bold">Something went wrong!</strong>
+            <span className="block sm:inline"> Please try refreshing the page or contact support if the problem persists.</span>
+            <details className="mt-2 text-left text-xs text-red-600">
+              <summary>Error Details</summary>
+              <pre className="whitespace-pre-wrap">
+                {this.state.error && this.state.error.toString()}
+                <br />
+                {this.state.errorInfo && this.state.errorInfo.componentStack}
+              </pre>
+            </details>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
This commit introduces an ErrorBoundary component and wraps the LookalikeFinderPage with it. This is intended to catch and gracefully handle any client-side rendering errors that might have been causing a blank page when you were interacting with the tool, particularly after clicking "Find Channels".

Changes:
- Created `src/components/utils/ErrorBoundary.jsx` with a standard React error boundary implementation.
- Modified `src/App.jsx` to use this ErrorBoundary around the `LookalikeFinderPage` route.
- Reviewed data access patterns within `LookalikeFinderPage.jsx` for rendering results, confirming robust use of optional chaining and fallbacks.

This should help in diagnosing and preventing blank page issues by providing a fallback UI and detailed error logging in the console if a rendering error occurs.