### PR TITLE
fix: Import CardFooter in LookalikeFinderPage

### DIFF
--- a/src/pages/tools/LookalikeFinderPage.jsx
+++ b/src/pages/tools/LookalikeFinderPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';


### PR DESCRIPTION
This commit resolves a ReferenceError for CardFooter in LookalikeFinderPage.jsx. The CardFooter component was being used without being imported from '@/components/ui/card'.

The missing import has been added, which should prevent the page from crashing when attempting to render CardFooter, particularly during loading states or when displaying results.