### PR TITLE
Fix: Address silent errors in channel analysis tools

### DIFF
--- a/src/pages/tools/BulkChannelAnalyzer.jsx
+++ b/src/pages/tools/BulkChannelAnalyzer.jsx
@@ -15,12 +15,13 @@ export default function BulkChannelAnalyzer() {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
 
   const handleAnalyze = async () => {
+    let specificErrorHandled = false; // 1. Initialize flag
     if (!channelUrls.trim()) return;
     
     setIsAnalyzing(true);
     setLoading(true);
-    setError(null);
-    setResults([]);
+    setError(null); // Clear previous errors
+    setResults([]); // Clear previous results
     
     try {
       const urls = parseBulkInput(channelUrls);
@@ -79,9 +80,15 @@ export default function BulkChannelAnalyzer() {
       setResults(analysisResults);
       
     } catch (error) {
+      specificErrorHandled = true; // 2. Set flag in outer catch
       console.error('Error analyzing channels:', error);
       setError(error.message || 'Failed to analyze channels. Please try again.');
     } finally {
+      // 4. Add logic in finally
+      // This check uses the component's state variable `results`.
+      if (!specificErrorHandled && results.length === 0) {
+        setError("No data found for any of the provided channels or an API error occurred. Please check the URLs and try again.");
+      }
       setIsAnalyzing(false);
       setLoading(false);
     }

--- a/src/pages/tools/ChannelAnalytics.jsx
+++ b/src/pages/tools/ChannelAnalytics.jsx
@@ -17,12 +17,17 @@ export default function ChannelAnalytics() {
   const [monthlyBreakdown, setMonthlyBreakdown] = useState([]);
 
   const handleAnalyze = async () => {
+    let specificErrorHandled = false; // 1. Initialize flag
     if (!channelUrl.trim()) return;
     
     setIsAnalyzing(true);
     setLoading(true);
-    setError(null);
+    setError(null); // Clear previous errors
     
+    // It's important that channelData and videos are reset if a new analysis starts
+    // setChannelData(null); // Optional: Reset data explicitly if needed, though new analysis overwrites or fails
+    // setVideos([]); // Optional: Reset data explicitly
+
     try {
       // Extract channel ID from URL
       let channelId = youtubeApiService.extractChannelId(channelUrl);
@@ -53,9 +58,16 @@ export default function ChannelAnalytics() {
       setMonthlyBreakdown(breakdown);
       
     } catch (error) {
+      specificErrorHandled = true; // 2. Set flag in catch
       console.error('Error analyzing channel:', error);
       setError(error.message || 'Failed to analyze channel. Please check the URL and try again.');
     } finally {
+      // 3. Add logic in finally
+      // This check uses the component's state variables `channelData` and `videos`.
+      // These would have been updated by `setChannelData` and `setVideos` in the `try` block if successful.
+      if (!specificErrorHandled && (channelData === null || videos.length === 0)) {
+        setError("No data found or API error occurred. Please check the URL and try again.");
+      }
       setIsAnalyzing(false);
       setLoading(false);
     }

--- a/src/pages/tools/ChannelComparison.jsx
+++ b/src/pages/tools/ChannelComparison.jsx
@@ -20,12 +20,13 @@ export default function ChannelComparison() {
   const [channelPrices, setChannelPrices] = useState({});
 
   const handleAnalyze = async () => {
+    let specificErrorHandled = false; // 1. Initialize flag
     if (!channelUrls.trim()) return;
     
     setIsAnalyzing(true);
     setLoading(true);
-    setError(null);
-    setChannelsData([]);
+    setError(null); // Clear previous errors
+    setChannelsData([]); // Clear previous results
     
     try {
       // Parse bulk input
@@ -116,10 +117,19 @@ export default function ChannelComparison() {
       
       setChannelsData(results);
       
+      // If results is empty here, it means all individual channels failed processing
+      // The check in `finally` will handle this.
+
     } catch (error) {
+      specificErrorHandled = true; // 2. Set flag in outer catch
       console.error('Error comparing channels:', error);
       setError(error.message || 'Failed to compare channels. Please check the URLs and try again.');
     } finally {
+      // 4. Add logic in finally
+      // This check uses the component's state variable `channelsData`.
+      if (!specificErrorHandled && channelsData.length === 0) {
+        setError("No data found for any of the provided channels or an API error occurred. Please check the URLs and try again.");
+      }
       setIsAnalyzing(false);
       setLoading(false);
     }

--- a/src/services/youtubeApi.js
+++ b/src/services/youtubeApi.js
@@ -67,14 +67,25 @@ class YouTubeApiService {
       }
     });
 
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.error?.message || `API request failed: ${response.status}`);
-    }
+    try { // New try block
+      const response = await fetch(url);
 
-    return response.json();
+      if (!response.ok) {
+        // This handles API errors (e.g., 400, 403, 404)
+        const errorData = await response.json().catch(() => ({ message: 'Failed to parse error response from API' }));
+        throw new Error(errorData.error?.message || `API request failed: ${response.status}`);
+      }
+
+      // Try to parse JSON, this can also fail if response is not valid JSON
+      return await response.json();
+    } catch (error) { // New catch block
+      // Log the error for server-side/dev visibility
+      console.error('Error in makeRequest (network, JSON parsing, or API error):', error);
+      // Re-throw the error to be handled by the calling component
+      // If it's an error we've already processed (like from !response.ok), it will be rethrown.
+      // If it's a new network error or JSON parsing error, it will be thrown.
+      throw error;
+    }
   }
 
   extractChannelId(url) {


### PR DESCRIPTION
I've made the following improvements:

1.  **Enhanced `youtubeApiService.js` Error Handling:**
    *   I've wrapped `fetch` and `response.json()` calls in `makeRequest` with a global try-catch to handle network errors and JSON parsing failures. Errors are re-thrown to be caught by UI components.

2.  **Improved User Feedback in Analytical Tools:**
    *   I've modified `ChannelAnalytics.jsx`, `ChannelComparison.jsx`, and `BulkChannelAnalyzer.jsx`.
    *   Each tool now checks in the `finally` block of its main analysis function if any data was successfully retrieved.
    *   If no data is present (e.g., all API calls returned empty, or individual processing steps failed without a top-level error), a message "No data found or API error occurred" (or a similar context-specific message) is displayed to you via `setError`.
    *   This ensures you are not left with a blank "Analyzing..." state or empty results without explanation.

These changes address the issue where tools would silently fail to load data without providing an error message to you, particularly when YouTube API requests might succeed with an HTTP 200 but return no items, or when individual requests in bulk tools failed.