### PR TITLE
Fix: Resolve 'cannot read undefined' error in channel ID utility

### DIFF
--- a/src/services/youtubeApi.js
+++ b/src/services/youtubeApi.js
@@ -151,9 +151,16 @@ class YouTubeApiService {
       // Fallback: if forUsername fails, and it looked like a handle, try searching
       if (url.includes('/@') || username.startsWith('@')) {
         const handle = username.startsWith('@') ? username : `@${username}`;
-        const searchData = await this.makeRequest('search', { part: 'id', q: handle, type: 'channel', maxResults: 1 });
+        // Search API is better for @handles.
+        // part: 'snippet' is needed to get snippet.channelId
+        const searchData = await this.makeRequest('search', { part: 'snippet', q: handle, type: 'channel', maxResults: 1 });
+
         if (searchData.items && searchData.items.length > 0) {
-          return searchData.items[0].snippet.channelId;
+          const item = searchData.items[0];
+          // Safely access channelId
+          if (item && item.snippet && typeof item.snippet.channelId === 'string') {
+            return item.snippet.channelId;
+          }
         }
       }
 


### PR DESCRIPTION
Corrects an error in `youtubeApiService.js` within the `getChannelIdFromCustomUrl` method. The fallback logic for resolving channel IDs from @handle style URLs could previously attempt to access `snippet.channelId` on an undefined object if the YouTube Search API returned unexpected item structures.

Changes:
- I modified the YouTube Search API call within `getChannelIdFromCustomUrl` to request `part: 'snippet'` instead of `part: 'id'`, as `channelId` is located within the snippet for channel search results.
- I added robust checks to ensure `item`, `item.snippet`, and `item.snippet.channelId` are valid and `channelId` is a string before accessing them.
- This prevents the "Cannot read properties of undefined (reading 'channelId')" runtime error.

This fix should allow the channel analysis tools (`ChannelAnalytics`, `ChannelComparison`, `BulkChannelAnalyzer`) to more gracefully handle custom URLs, and either resolve the channel ID correctly or allow the existing error handling in the components to display an appropriate message to you if the ID cannot be determined.